### PR TITLE
Fix compilation under MingW64

### DIFF
--- a/gen_uuid.c
+++ b/gen_uuid.c
@@ -38,6 +38,8 @@
  */
 #define _SVID_SOURCE
 
+#include "c.h"
+
 #ifdef _WIN32
 #define _WIN32_WINNT 0x0500
 #include <windows.h>
@@ -91,7 +93,6 @@
 #include "uuidP.h"
 #include "uuidd.h"
 #include "randutils.h"
-#include "c.h"
 
 #ifdef HAVE_TLS
 #define THREAD_LOCAL static __thread

--- a/gen_uuid.c
+++ b/gen_uuid.c
@@ -144,7 +144,7 @@ static int flock(int fd, int op)
 
 #endif /* LOCK_EX */
 
-#ifdef _WIN32
+#if !defined(__MINGW64__) && defined(_WIN32)
 static void gettimeofday (struct timeval *tv, void *dummy)
 {
 	FILETIME	ftime;


### PR DESCRIPTION
File fails to compile because `c.h`, which includes `config.h`, is included *after* all configuration macros are tested, therefore defeating the purpose of having the configuration in the first place.